### PR TITLE
Fix supplemental and raw functions to call with args

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -218,8 +218,8 @@ var CruisePage = React.createClass({
         return (
           <div>
           <h4>Data As Received</h4>
-          {intermediate_files}
-          {raw_files}
+          {intermediate_files(intermediate)}
+          {raw_files(raw)}
           </div>
         )
       }


### PR DESCRIPTION
The supplemental_files function was not calling raw_files and intermediate_files with arguments.  So I added these both in.  Probably because there were no public raw or intermediate files to check the code with. 